### PR TITLE
Add a script to produce telephone-friendly flash card decks.

### DIFF
--- a/go.py
+++ b/go.py
@@ -1,0 +1,27 @@
+#! python
+
+# Set the topics you want to work on here.
+Files=["abstract-algebra", "topology", "representation_theory"]
+
+import subprocess
+
+def go(dothis):
+    print(dothis)
+    return subprocess.getoutput(dothis)
+
+# For now, leave cards as avery5371, but shift to onecard on compilation.
+Ftex=[i + ".tex" for i in Files]
+for i in Ftex:
+    go("sed 's/avery5371/onecard/' <" + i + " > tmp."+i)
+    go("pdflatex tmp."+i)
+
+Count=go("egrep '(\\\\Dcard|\\\\Card|begin.flashcard)' " + " ".join(Ftex)  + " | wc -l")
+print("--------------------\n\t"+str(Count)+" cards.\n--------------------")
+
+go("rm counts; for i in `seq 1 2 " + str(2*int(Count)-2) + "`; do echo $i >> counts; done")
+Pages=go("shuf counts | awk '{print $1 \",\" $1+1}'| tr '\n' ','|sed 's/,$//'")
+
+go("rm -f mid.pdf mid1.pdf")
+go("pdfjam --trim '0in 9.5in 5in 1in' " + "  ".join([" tmp."+i +".pdf " for i in Files]) + " -o mid1.pdf")
+go("pdfjam mid1.pdf \"" + Pages + "\" --no-tidy -o mid.pdf")
+go("pdfcrop --clip mid.pdf cards.pdf")

--- a/go.py
+++ b/go.py
@@ -22,6 +22,6 @@ go("rm counts; for i in `seq 1 2 " + str(2*int(Count)-2) + "`; do echo $i >> cou
 Pages=go("shuf counts | awk '{print $1 \",\" $1+1}'| tr '\n' ','|sed 's/,$//'")
 
 go("rm -f mid.pdf mid1.pdf")
-go("pdfjam --trim '0in 9.5in 5in 1in' " + "  ".join([" tmp."+i +".pdf " for i in Files]) + " -o mid1.pdf")
+go("pdfjam  " + "  ".join([" tmp."+i +".pdf " for i in Files]) + " -o mid1.pdf")
 go("pdfjam mid1.pdf \"" + Pages + "\" --no-tidy -o mid.pdf")
 go("pdfcrop --clip mid.pdf cards.pdf")

--- a/makefile
+++ b/makefile
@@ -1,0 +1,13 @@
+
+cards:
+	python ./go.py
+
+clean:
+	rm -f *.aux *.log *.pdf counts tmp.* odes.out
+
+all:
+	for i in *tex; do \
+	   	if [ $$i != tikzlibrarycd.code.tex ]; then \
+			pdflatex $$i; \
+		fi; done;
+

--- a/onecard.cfg
+++ b/onecard.cfg
@@ -1,0 +1,55 @@
+%%
+%% This is file is a hack of `avery5371.cfg' to put one flash card per page
+%%
+%% The original source files were:
+%%
+%% flashcards.dtx  (with options: `avery5371')
+%% 
+%% FlashCards LaTeX2e Class for Typesetting Double Sided Cards
+%% Copyright (C) 2000  Alexander M. Budge <ambudge@mit.edu>
+%% 
+%% This program is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published by
+%% the Free Software Foundation; either version 2 of the License, or
+%% (at your option) any later version.
+%% 
+%% This program is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%% GNU General Public License for more details.
+%% 
+%% You should have received a copy of the GNU General Public License
+%% along with this program (the file COPYING); if not, write to the
+%% Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+%% 
+%% \CharacterTable
+%%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
+%%   Lower-case    \a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z
+%%   Digits        \0\1\2\3\4\5\6\7\8\9
+%%   Exclamation   \!     Double quote  \"     Hash (number) \#
+%%   Dollar        \$     Percent       \%     Ampersand     \&
+%%   Acute accent  \'     Left paren    \(     Right paren   \)
+%%   Asterisk      \*     Plus          \+     Comma         \,
+%%   Minus         \-     Point         \.     Solidus       \/
+%%   Colon         \:     Semicolon     \;     Less than     \<
+%%   Equals        \=     Greater than  \>     Question mark \?
+%%   Commercial at \@     Left bracket  \[     Backslash     \\
+%%   Right bracket \]     Circumflex    \^     Underscore    \_
+%%   Grave accent  \`     Left brace    \{     Vertical bar  \|
+%%   Right brace   \}     Tilde         \~}
+%%
+\NeedsTeXFormat{LaTeX2e}[1996/12/01]
+\ProvidesFile{onecard.cfg}
+\newcommand{\cardpapermode}{portrait}
+\newcommand{\cardpaper}{letterpaper}
+\newcommand{\cardrows}{1}
+\newcommand{\cardcolumns}{1}
+\setlength{\cardheight}{2.0in}
+\setlength{\cardwidth}{3.5in}
+\setlength{\topoffset}{0in}
+\setlength{\oddoffset}{0in}
+\setlength{\evenoffset}{0in}
+
+\endinput
+%%
+%% End of file `avery5371.cfg'.


### PR DESCRIPTION
I wanted to run through your flash cards on my telephone, so I hacked together this script to put one card per page, join multiple subjects, shuffle the cards, then trim the margins.

The makefile allows one to build via 'make' and remove temp files (and the output, cards.pdf) via 'make clean'.